### PR TITLE
feat: implement offline-first mode with optional API key

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -15,13 +15,17 @@ pub struct Args {
     #[arg(long, short = 'd', global = true)]
     pub dry_run: bool,
 
+    /// Force offline mode even if online is preferred
+    #[arg(long, global = true)]
+    pub offline: bool,
+
     /// Recursively search files in subdirectory
     #[arg(long, short = 'r', global = true)]
     pub recursive: bool,
 
-    /// Use offline mode (extension-based categorization)
+    /// Use online mode (AI categorization)
     #[arg(long, short = 'o', global = true)]
-    pub offline: bool,
+    pub online: bool,
 
     /// Skip AI deep inspection for sub-categorization (faster)
     #[arg(long, global = true)]
@@ -34,14 +38,16 @@ pub struct Args {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Organize downloads using AI categorization (CLI mode)
+    /// Organize downloads (offline-first by default)
     #[command(name = "organize")]
     Organize {
         #[arg(long, help = "Preview changes without moving files")]
         dry_run: bool,
         #[arg(long, default_value_t = 5, help = "Maximum concurrent API requests")]
         max_concurrent: usize,
-        #[arg(long, help = "Use offline mode (extension-based categorization)")]
+        #[arg(long, help = "Use online mode (AI categorization)")]
+        online: bool,
+        #[arg(long, help = "Force offline mode (extension-based categorization)")]
         offline: bool,
         #[arg(long, help = "Recursively search files in subdirectory")]
         recursive: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,14 +30,7 @@ async fn main() -> Result<()> {
         None => {
             // Default: Launch TUI
             let config = get_or_prompt_config()?;
-            run_app(
-                config,
-                args.path,
-                args.recursive,
-                args.dry_run,
-                args.offline,
-            )
-            .await?;
+            run_app(config, args.path, args.recursive, args.dry_run).await?;
         }
     }
     Ok(())

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -37,6 +37,10 @@ pub struct App {
     pub dry_run: bool,
     pub offline: bool,
 
+    // Online mode state
+    pub online_requested: bool,
+    pub online_available: bool,
+
     // File data
     pub batch: Option<FileBatch>,
     pub plan: Option<OrganizationPlan>,
@@ -60,13 +64,10 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(
-        config: Config,
-        target_path: PathBuf,
-        recursive: bool,
-        dry_run: bool,
-        offline: bool,
-    ) -> Self {
+    pub fn new(config: Config, target_path: PathBuf, recursive: bool, dry_run: bool) -> Self {
+        // Initialize offline-first based on config preference
+        let online_requested = config.prefer_online;
+
         Self {
             state: AppState::Scanning,
             tab: Tab::Files,
@@ -74,7 +75,9 @@ impl App {
             target_path,
             recursive,
             dry_run,
-            offline,
+            offline: !online_requested,
+            online_requested,
+            online_available: false,
             batch: None,
             plan: None,
             file_list_state: 0,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -290,8 +290,10 @@ fn draw_progress_tab(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("Mode: ", Style::default().fg(Color::Cyan)),
             Span::raw(if app.offline {
                 "Offline"
-            } else {
+            } else if app.online_available {
                 "Online (AI)"
+            } else {
+                "Online (Unavailable)"
             }),
         ]),
     ];
@@ -316,16 +318,13 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_offline_toggle(frame: &mut Frame, app: &App, area: Rect) {
-    let toggle_text = if app.offline {
-        "Offline Mode: ON"
+    // Determine display text and style based on mode and availability
+    let (toggle_text, toggle_style) = if app.offline {
+        ("Offline Mode", Style::default().fg(Color::Green))
+    } else if app.online_available {
+        ("Online Mode ✓", Style::default().fg(Color::Green))
     } else {
-        "Offline Mode: OFF"
-    };
-
-    let toggle_style = if app.offline {
-        Style::default().fg(Color::Green)
-    } else {
-        Style::default().fg(Color::Red)
+        ("Online Mode ✗", Style::default().fg(Color::Yellow))
     };
 
     let toggle = Paragraph::new(toggle_text)
@@ -346,11 +345,11 @@ fn draw_offline_toggle(frame: &mut Frame, app: &App, area: Rect) {
 fn draw_help_bar(frame: &mut Frame, app: &App, area: Rect) {
     let help_text = match app.state {
         AppState::FileList => {
-            "[o] Organize  [t] Toggle offline  [Tab] Switch view  [j/k] Navigate  [q] Quit"
+            "[o] Organize  [t] Toggle mode  [Tab] Switch view  [j/k] Navigate  [q] Quit"
         }
         AppState::Fetching => "Fetching... Please wait",
         AppState::PlanReview => {
-            "[c] Confirm  [t] Toggle offline  [Tab] Switch view  [j/k] Navigate  [q] Quit"
+            "[c] Confirm  [t] Toggle mode  [Tab] Switch view  [j/k] Navigate  [q] Quit"
         }
         AppState::Moving => "Moving files... Please wait",
         AppState::Done => "[q] Quit  [r] Restart",


### PR DESCRIPTION
- Change default behavior to offline-first (extension-based categorization)
- Add --online flag to CLI for AI categorization (replaces --offline default)
- Make API key optional during initial setup with skip option
- Add TUI 't' key toggle to switch between online/offline modes
- Persist user's mode preference in config (prefer_online field)
- Add silent mode to GeminiClient to prevent TUI display corruption
- Add silent save methods for config persistence in TUI
- Update UI indicators to show online availability status