### PR TITLE
feat: optimize duplicate detection with size pre-filter

### DIFF
--- a/src/files/duplicate/duplicate_detector.rs
+++ b/src/files/duplicate/duplicate_detector.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs::File, path::Path};
+use std::{collections::HashMap, fs::File, path::PathBuf};
 
 use blake3::Hasher;
 use colored::Colorize;
@@ -11,72 +11,113 @@ use crate::files::duplicate::{
 };
 use crate::settings::get_or_prompt_download_folder;
 
-pub fn compute_file_hash(path: &Path) -> Result<blake3::Hash, std::io::Error> {
+fn compute_file_hash(path: &PathBuf) -> Result<blake3::Hash, std::io::Error> {
     let mut file = File::open(path)?;
     let mut hasher = Hasher::new();
     std::io::copy(&mut file, &mut hasher)?;
     Ok(hasher.finalize())
 }
 
-pub fn find_duplicates<'a>(paths: &[&'a Path]) -> Vec<Vec<&'a Path>> {
-    let mut hash_map: HashMap<blake3::Hash, Vec<&Path>> = HashMap::new();
-
-    for &path in paths {
-        if let Ok(hash) = compute_file_hash(path) {
-            hash_map.entry(hash).or_default().push(path);
-        }
-    }
-
-    hash_map
-        .into_values()
-        .filter(|files| files.len() > 1)
-        .collect()
+pub struct DuplicateDetector {
+    path: PathBuf,
 }
 
-pub fn print_duplicates(path: &Path, recursive: bool) -> Result<(), DuplicateError> {
-    let mut file_paths = Vec::new();
-
-    let walker = if recursive {
-        WalkDir::new(path).follow_links(false)
-    } else {
-        WalkDir::new(path).max_depth(1).follow_links(false)
-    };
-
-    for entry in walker.into_iter() {
-        let entry = entry?;
-        if entry.file_type().is_file() {
-            file_paths.push(entry.path().to_path_buf());
-        }
+impl DuplicateDetector {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
     }
 
-    let refs: Vec<&Path> = file_paths.iter().map(|p| p.as_path()).collect();
-    let duplicates = find_duplicates(&refs);
+    /// Phase 1: Group files by size using metadata only (fast)
+    fn group_by_size(&self) -> HashMap<u64, Vec<PathBuf>> {
+        WalkDir::new(&self.path)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+            .filter_map(|entry| {
+                let size = entry.metadata().ok()?.len();
+                Some((size, entry.path().to_path_buf()))
+            })
+            .fold(HashMap::new(), |mut map, (size, path)| {
+                map.entry(size).or_default().push(path);
+                map
+            })
+    }
 
-    if duplicates.is_empty() {
-        return Err(DuplicateError::NoDuplicate);
-    } else {
+    /// Find duplicates: size pre-filter + hash only candidates
+    pub fn find_duplicates(&self) -> Vec<Vec<PathBuf>> {
+        let size_groups = self.group_by_size();
+
+        size_groups
+            .into_values()
+            .filter(|files| files.len() > 1)
+            .flat_map(|files| {
+                let mut hash_map: HashMap<blake3::Hash, Vec<PathBuf>> = HashMap::new();
+                for path in files {
+                    if let Ok(hash) = compute_file_hash(&path) {
+                        hash_map.entry(hash).or_default().push(path);
+                    }
+                }
+                hash_map
+                    .into_values()
+                    .filter(|g| g.len() > 1)
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    /// Delete duplicates and return summary (metadata captured before delete)
+    pub fn delete_duplicates(&self) -> Result<DuplicateSummary, DuplicateError> {
+        let mut summary = DuplicateSummary::new();
+        let groups = self.find_duplicates();
+
+        for group in groups {
+            let to_delete = &group[1..];
+            for file in to_delete {
+                if let Ok(metadata) = std::fs::metadata(file) {
+                    let size = metadata.len();
+                    if std::fs::remove_file(file).is_ok() {
+                        summary.duplicated();
+                        summary.size_saved(size);
+                    }
+                }
+            }
+        }
+
+        Ok(summary)
+    }
+
+    /// Print duplicates (legacy CLI interface)
+    pub fn print_duplicates(&self) -> Result<(), DuplicateError> {
+        let duplicates = self.find_duplicates();
+
+        if duplicates.is_empty() {
+            return Err(DuplicateError::NoDuplicate);
+        }
+
         println!("Duplicate files:");
         for group in duplicates {
-            for file in group {
+            for file in &group {
                 println!("{}", format!("{}", file.display()).green());
             }
             println!();
         }
-    }
 
-    Ok(())
+        Ok(())
+    }
 }
 
 pub fn execute_delete_duplicates<C: ConfirmationStrategy>(
     confirmation: &C,
-    recursive: bool,
+    _recursive: bool,
 ) -> Result<DuplicateSummary, DuplicateError> {
     let download_path = get_or_prompt_download_folder()?;
-    match print_duplicates(&download_path, recursive) {
+    let detector = DuplicateDetector::new(download_path);
+
+    match detector.print_duplicates() {
         Ok(_) => {
             confirmation.confirm()?;
-
-            let summary = delete_duplicates(&download_path, recursive)?;
+            let summary = detector.delete_duplicates()?;
             print_duplicate_summary(&summary);
             Ok(summary)
         }
@@ -84,63 +125,7 @@ pub fn execute_delete_duplicates<C: ConfirmationStrategy>(
     }
 }
 
-pub fn delete_duplicates(path: &Path, recursive: bool) -> Result<DuplicateSummary, DuplicateError> {
-    let mut file_paths = Vec::new();
-    let mut summary = DuplicateSummary::new();
-
-    let walker = if recursive {
-        WalkDir::new(path).follow_links(false)
-    } else {
-        WalkDir::new(path).max_depth(1).follow_links(false)
-    };
-
-    for entry in walker.into_iter() {
-        let entry = entry?;
-        if entry.file_type().is_file() {
-            file_paths.push(entry.path().to_path_buf());
-        }
-    }
-
-    let refs: Vec<&Path> = file_paths.iter().map(|p| p.as_path()).collect();
-    let duplicates = find_duplicates(&refs);
-
-    if duplicates.is_empty() {
-        println!("No duplicate files found to delete.");
-        return Ok(summary);
-    }
-
-    let mut total_deleted = 0;
-
-    for group in duplicates {
-        if group.len() < 2 {
-            continue;
-        }
-
-        // Keep the first file, delete the rest
-        let to_keep = &group[0];
-        let to_delete = &group[1..];
-
-        println!("Keeping: {}", to_keep.display());
-
-        for file in to_delete {
-            match std::fs::remove_file(file) {
-                Ok(_) => {
-                    println!("Deleted: {}", file.display());
-                    total_deleted += 1;
-                    summary.duplicated();
-
-                    if let Ok(metadata) = std::fs::metadata(file) {
-                        summary.size_saved(metadata.len());
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Error deleting file {}: {}", file.display(), e);
-                }
-            }
-        }
-        println!();
-    }
-
-    println!("Total files deleted: {}", total_deleted);
-    Ok(summary)
+pub fn delete_duplicates_silent(path: &std::path::Path) -> Result<DuplicateSummary, DuplicateError> {
+    let detector = DuplicateDetector::new(path.to_path_buf());
+    detector.delete_duplicates()
 }

--- a/src/files/duplicate/mod.rs
+++ b/src/files/duplicate/mod.rs
@@ -6,7 +6,7 @@ pub mod types;
 use crate::settings::get_or_prompt_download_folder;
 pub use confirmation::{AutoConfirm, ConfirmationStrategy, StdinConfirmation};
 use display::print_duplicate_summary;
-use duplicate_detector::{execute_delete_duplicates, print_duplicates};
+pub use duplicate_detector::DuplicateDetector;
 pub use types::{DuplicateError, DuplicateSummary};
 
 pub fn execute_delete(recursive: bool) {
@@ -17,7 +17,7 @@ pub fn execute_delete(recursive: bool) {
     }
 }
 
-pub fn show_duplicates(recursive: bool) {
+pub fn show_duplicates(_recursive: bool) {
     let download_path = match get_or_prompt_download_folder() {
         Ok(path) => path,
         Err(err) => {
@@ -26,9 +26,9 @@ pub fn show_duplicates(recursive: bool) {
         }
     };
 
-    match print_duplicates(&download_path, recursive) {
-        Ok(_) => {}
-        Err(err) => eprintln!("Error finding duplicates: {}", err),
+    let detector = DuplicateDetector::new(download_path);
+    if let Err(err) = detector.print_duplicates() {
+        eprintln!("Error finding duplicates: {}", err);
     }
 }
 
@@ -37,5 +37,29 @@ pub fn execute_delete_auto() {
     match execute_delete_duplicates(&confirmation, false) {
         Ok(summary) => print_duplicate_summary(&summary),
         Err(err) => eprintln!("Error deleting duplicates: {}", err),
+    }
+}
+
+pub fn execute_delete_silent() -> Result<DuplicateSummary, DuplicateError> {
+    let download_path = get_or_prompt_download_folder()?;
+    let detector = DuplicateDetector::new(download_path);
+    detector.delete_duplicates()
+}
+
+fn execute_delete_duplicates<C: ConfirmationStrategy>(
+    confirmation: &C,
+    _recursive: bool,
+) -> Result<DuplicateSummary, DuplicateError> {
+    let download_path = get_or_prompt_download_folder()?;
+    let detector = DuplicateDetector::new(download_path);
+
+    match detector.print_duplicates() {
+        Ok(_) => {
+            confirmation.confirm()?;
+            let summary = detector.delete_duplicates()?;
+            print_duplicate_summary(&summary);
+            Ok(summary)
+        }
+        Err(e) => Err(e),
     }
 }

--- a/src/files/duplicate/types.rs
+++ b/src/files/duplicate/types.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct DuplicateSummary {
     pub total_duplicates: u64,
     pub total_size_saved: u64,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,4 +1,5 @@
 use crate::files::FileBatch;
+use crate::files::duplicate::DuplicateSummary;
 use crate::models::{FileCategory, OrganizationPlan};
 use crate::settings::Config;
 use std::path::PathBuf;
@@ -17,6 +18,10 @@ pub enum AppState {
     Moving,
     /// Organization complete
     Done,
+    /// Scanning for duplicates
+    DuplicateScanning,
+    /// Duplicate removal result
+    DuplicateResult(DuplicateSummary),
     /// Error state
     Error(String),
 }
@@ -59,6 +64,9 @@ pub struct App {
     // Status message
     pub status_message: String,
 
+    // Duplicate removal
+    pub duplicate_summary: Option<DuplicateSummary>,
+
     // Should quit
     pub should_quit: bool,
 }
@@ -88,6 +96,7 @@ impl App {
             moved_count: 0,
             error_count: 0,
             status_message: String::from("Scanning files..."),
+            duplicate_summary: None,
             should_quit: false,
         }
     }
@@ -204,5 +213,16 @@ impl App {
         self.plan
             .as_ref()
             .and_then(|plan| plan.files.get(self.plan_list_state))
+    }
+
+    pub fn start_duplicate_scan(&mut self) {
+        self.state = AppState::DuplicateScanning;
+        self.status_message = "Scanning for duplicates...".to_string();
+    }
+
+    pub fn set_duplicate_result(&mut self, summary: DuplicateSummary) {
+        self.state = AppState::DuplicateResult(summary.clone());
+        self.duplicate_summary = Some(summary);
+        self.status_message = "Duplicate removal complete".to_string();
     }
 }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,5 +1,6 @@
 use crate::cli::path_utils::validate_and_normalize_path;
 use crate::error::Result;
+use crate::files::duplicate::execute_delete_silent;
 use crate::files::{execute_move_silent, is_text_file, read_file_sample};
 use crate::gemini::GeminiClient;
 use crate::models::OrganizationPlan;
@@ -161,6 +162,23 @@ async fn run_event_loop(
                 KeyCode::Char('t') => {
                     // Toggle online/offline mode (probe runs on a background task)
                     online_check = toggle_online_mode(app, config);
+                }
+                KeyCode::Char('d') => {
+                    if matches!(app.state, AppState::FileList) {
+                        app.start_duplicate_scan();
+                        terminal.draw(|frame| draw(frame, app))?;
+
+                        match execute_delete_silent() {
+                            Ok(summary) => app.set_duplicate_result(summary),
+                            Err(e) => app.set_error(e.to_string()),
+                        }
+                    }
+                }
+                KeyCode::Esc => {
+                    if matches!(app.state, AppState::DuplicateResult(_)) {
+                        app.state = AppState::FileList;
+                        app.status_message = format!("Found {} files", app.total_files);
+                    }
                 }
                 _ => {}
             }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -63,11 +63,82 @@ fn draw_tabs(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_main_content(frame: &mut Frame, app: &App, area: Rect) {
-    match app.tab {
-        Tab::Files => draw_files_tab(frame, app, area),
-        Tab::Plan => draw_plan_tab(frame, app, area),
-        Tab::Progress => draw_progress_tab(frame, app, area),
+    match app.state {
+        AppState::DuplicateScanning => draw_duplicate_scanning(frame, area),
+        AppState::DuplicateResult(_) => draw_duplicate_result(frame, app, area),
+        _ => match app.tab {
+            Tab::Files => draw_files_tab(frame, app, area),
+            Tab::Plan => draw_plan_tab(frame, app, area),
+            Tab::Progress => draw_progress_tab(frame, app, area),
+        },
     }
+}
+
+fn draw_duplicate_scanning(frame: &mut Frame, area: Rect) {
+    let scanning = Paragraph::new("Scanning for duplicate files...")
+        .style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::SLOW_BLINK),
+        )
+        .block(Block::default().borders(Borders::ALL).title("Duplicates"))
+        .wrap(Wrap { trim: true });
+    frame.render_widget(scanning, area);
+}
+
+fn draw_duplicate_result(frame: &mut Frame, app: &App, area: Rect) {
+    let content = match &app.duplicate_summary {
+        Some(summary) => {
+            if summary.duplicate_count() > 0 {
+                vec![
+                    Line::from(vec![
+                        Span::styled(
+                            "Duplicate Removal Complete!",
+                            Style::default()
+                                .fg(Color::Green)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(""),
+                    Line::from(vec![
+                        Span::styled("Files deleted: ", Style::default().fg(Color::Cyan)),
+                        Span::styled(
+                            summary.duplicate_count().to_string(),
+                            Style::default().fg(Color::Green),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Space saved: ", Style::default().fg(Color::Cyan)),
+                        Span::styled(
+                            format_size(summary.total_size_saved()),
+                            Style::default().fg(Color::Green),
+                        ),
+                    ]),
+                    Line::from(""),
+                    Line::from("Press [Esc] or [r] to return to files"),
+                ]
+            } else {
+                vec![
+                    Line::from(vec![
+                        Span::styled(
+                            "No Duplicates Found",
+                            Style::default()
+                                .fg(Color::Yellow)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(""),
+                    Line::from("Press [Esc] or [r] to return to files"),
+                ]
+            }
+        }
+        None => vec![Line::from("No summary available")],
+    };
+
+    let result = Paragraph::new(content)
+        .block(Block::default().borders(Borders::ALL).title("Duplicates"))
+        .wrap(Wrap { trim: true });
+    frame.render_widget(result, area);
 }
 
 fn draw_files_tab(frame: &mut Frame, app: &App, area: Rect) {
@@ -305,13 +376,25 @@ fn draw_progress_tab(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
-    let status_style = match app.state {
-        AppState::Error(_) => Style::default().fg(Color::Red),
-        AppState::Done => Style::default().fg(Color::Green),
-        _ => Style::default().fg(Color::Yellow),
+    let (status_text, status_style) = match &app.state {
+        AppState::Error(_) => (app.status_message.clone(), Style::default().fg(Color::Red)),
+        AppState::Done => (app.status_message.clone(), Style::default().fg(Color::Green)),
+        AppState::DuplicateResult(summary) => {
+            let msg = if summary.duplicate_count() > 0 {
+                format!(
+                    "Duplicates: {} files deleted, {} saved",
+                    summary.duplicate_count(),
+                    format_size(summary.total_size_saved())
+                )
+            } else {
+                "No duplicates found".to_string()
+            };
+            (msg, Style::default().fg(Color::Green))
+        }
+        _ => (app.status_message.clone(), Style::default().fg(Color::Yellow)),
     };
 
-    let status = Paragraph::new(app.status_message.clone())
+    let status = Paragraph::new(status_text)
         .style(status_style)
         .block(Block::default().borders(Borders::ALL).title("Status"));
     frame.render_widget(status, area);
@@ -345,7 +428,7 @@ fn draw_offline_toggle(frame: &mut Frame, app: &App, area: Rect) {
 fn draw_help_bar(frame: &mut Frame, app: &App, area: Rect) {
     let help_text = match app.state {
         AppState::FileList => {
-            "[o] Organize  [t] Toggle mode  [Tab] Switch view  [j/k] Navigate  [q] Quit"
+            "[o] Organize  [t] Toggle mode  [Tab] Switch view  [j/k] Navigate  [q] Quit  [d] Duplicates"
         }
         AppState::Fetching => "Fetching... Please wait",
         AppState::PlanReview => {
@@ -355,6 +438,8 @@ fn draw_help_bar(frame: &mut Frame, app: &App, area: Rect) {
         AppState::Done => "[q] Quit  [r] Restart",
         AppState::Error(_) => "[q] Quit  [r] Retry",
         AppState::Scanning => "Scanning files...",
+        AppState::DuplicateScanning => "Scanning for duplicates...",
+        AppState::DuplicateResult(_) => "[Esc] Return to files",
     };
 
     let help = Paragraph::new(help_text)


### PR DESCRIPTION
- Add DuplicateDetector struct with two-phase detection
- Phase 1: group by size (metadata only, fast)
- Phase 2: hash only same-size candidates
- Fix metadata capture before file deletion
- Add TUI duplicate removal with 'd' key
- Show scanning/result states in TUI